### PR TITLE
Improve readme and tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,14 @@
 # BeeChatNetwork
-**Open source, peer-to-peer, radio communication chat based on the [ZigBee standard](https://zigbeealliance.org/).**
+
+**Open source (MIT), peer-to-peer, radio communication chat based on the [ZigBee standard](https://zigbeealliance.org/).**
 
 ---
 
-**[Homepage]
-(https://beechat.network/)**
+**[Homepage](https://beechat.network/)**
 
-[GitHub Page]
-(https://github.com/beechatnetworkadmin/BeeChatNetwork/)
+[GitHub Page](https://github.com/beechatnetworkadmin/BeeChatNetwork/)
 
-[YouTube Channel]
-(https://www.youtube.com/channel/UCpkkP4lfeiD-UR6qxVQW3Dg)
-
-
-## License
->
-MIT License
->
-Copyright (c) 2020 BeechatNetworkAdmin
->
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
->
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
->
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+[YouTube Channel](https://www.youtube.com/channel/UCpkkP4lfeiD-UR6qxVQW3Dg)
 
 ---
 
@@ -43,9 +16,9 @@ SOFTWARE.
 
 BeeChat is an open source set of hardware and software which allows people to securely communicate over encrypted peer-to-peer short-range radio connections, and without relying on commercial infrastructure.
 
-**No SIM cards, no Internet required.**
-**No shady tracking.**
-**We all fully own the system, this way, no one can destroy it.**
+* **No SIM cards, no Internet required.**
+* **No shady tracking.**
+* **We all fully own the system, this way, no one can destroy it.**
 
 If you want to send a message to someone outside your range, people in between you two can act as a bridge, without ever knowing the contents of the encrypted message.
 
@@ -54,6 +27,7 @@ If you want to send a message to someone outside your range, people in between y
 BeeChat is extremely flexible. Here are just some of the ways we think BeeChat can be useful, but the possibilities are endless.
 
 * **Compromised Internet**
-In case of a natural disaster or civil unrest, normal internet may not be functional. In such a case, BeeChat can provide vital communication functionalities to allow users to stay in touch with friends and loved ones. 
+
+    In case of a natural disaster or civil unrest, normal internet may not be functional. In such a case, BeeChat can provide vital communication functionalities to allow users to stay in touch with friends and loved ones.
 
 * **Hacker-proof Internet Of Things (IOT)**

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,18 +1,4 @@
-# BeeChatNetwork
-Open source, peer-to-peer, radio communication chat based on the [ZigBee standard](https://zigbeealliance.org/).
-
-**[Homepage]
-(https://beechat.network/)**
-
-[GitHub Page]
-(https://github.com/beechatnetworkadmin/BeeChatNetwork/)
-
-[YouTube Channel]
-(https://www.youtube.com/channel/UCpkkP4lfeiD-UR6qxVQW3Dg)
-
-
-## License
-ZigBee uses the [MIT License](https://mit-license.org/), which should also be included in a text file within this folder.
+# BeeChatNetwork setup tutorial
 
 ---
 
@@ -20,122 +6,111 @@ ZigBee uses the [MIT License](https://mit-license.org/), which should also be in
 
 1. Getting Started
     1. Installing Java
-    
     2. Setting up the hardware
-        
     3. Configuring XCTU
-        1. Downloading XCTU
-        2. Setting up XCTU
-        
-    2. Setting up BeeChat
-    
-    3. Running BeeChat
-        * Command line arguments
-        
-2. Using BeeChat
 
-3. In The Future
+2. Running BeeChat
+    * Command line arguments
+
+3. Using BeeChat
+
+4. Building BeeChat from source
+
+5. In The Future
 
 ---
 
 ## Getting Started
+
 This section shows how to set up BeeChat.
 
 ### Installing Java
-BeeChat requires the **Java Runtime Environment Version 11** or later.
 
-To ensure you have the right version of Java installed, use `java -version`.
+BeeChat requires **Java 11** or later.
 
-* _If you are already using Java 11, you can skip the rest of this section._
+To install Java 11 (default `OpenJDK` builds provided by your Linux sdistribution):
 
+* **Fedora**
 
-To install Java 11 or later:
+    `sudo dnf install openjdk11`
 
-**Fedora**: 
-    
->`sudo dnf install openjdk11`
+* **Ubuntu (18.04 or later)**
 
+    `sudo apt install openjdk-11-jdk`
 
-Note: _other Java distributions may be used, but for the sake of this tutorial we will be using the OpenJDK._
+Then, ensure you have the right version of Java set as the default with `java -version`.
 
-Then, enter `sudo update-alternatives --config java` and follow the on-screen instructions to select OpenJDK 11.
+If not, run `sudo update-alternatives --config java` and follow the on-screen instructions to select the OpenJDK 11 as the default and check again.
 
-To check that you have configured Java correctly, use `java -version` again.
-    
+**Note**: it is also possible to use other Java distributions.
+If you wish to use a different one, or even have multiple distributions/versions installed side-by-side on your system (without interfering with the version installed by your system's package manager), it is recommended to use [SDKMAN!](https://sdkman.io/).
+
 ### Setting up the hardware
-In this tutorial we will be using parts from the [official parts list](https://beechat.network/parts-list/). Other ZigBee hardware may be used, but is not recommended and will not be explained in this tutorial. The process is more or less the same for both the [long range setup](https://beechat.network/long-range-setup/) and the [short range setup](https://beechat.network/short-range-setup/).
 
+In this tutorial we will be using parts from the [official parts list](https://beechat.network/parts-list/). Other ZigBee hardware may be used, but is not recommended and will not be explained in this tutorial. The process is more or less the same for both the [long range setup](https://beechat.network/long-range-setup/) and the [short range setup](https://beechat.network/short-range-setup/).
 
 ***NOTE:*** The Sparkfun Dongle and and XBee Module must be handled with care! Only touch the side edges of the boards, as touching the electronic components with bare hands can cause damage from electrostatic discharge (ESD).
 
 1. Connect the black XBee module to the red Sparkfun dongle by carefully pressing the connectors on the XBee module down into the ports on the Sparkfun dongle. If you are using the long-range setup, make sure the metal antenna connector on the XBee module is pointed outwards (away from the USB port on the Sparkfun dongle).
 
-* The following only applies if you are using the long-range setup:
-    2. Screw on the small metal SMA adapter onto the XBee module's connector.
-    3. Connect the antenna to the SMA adapter.
+* If you are using the long-range setup, these additional steps are needed:
+    1. Screw on the small metal SMA adapter onto the XBee module's connector.
+    2. Connect the antenna to the SMA adapter.
 
 Then, simply plug it into a USB port on your computer and move on to the next step.
-    
-    
+
 ### Configuring XCTU
-1. [Download the correct version of the XCTU configuration tool for your system.](https://www.digi.com/products/embedded-systems/digi-xbee/digi-xbee-tools/xctu#productsupport-utilities)
+
+1. [Download and install the correct version of the XCTU configuration tool for your system.](https://www.digi.com/products/embedded-systems/digi-xbee/digi-xbee-tools/xctu#productsupport-utilities)
 2. Open the newly installed XCTU program.
 3. Click on the second button from the top left (with the magnifying glass) and click it.
-4. A menu should have appeared. Check the box next to your radio module (it should be labeled something like `/dev/ttyUSB`). Then press `Next >`.
+4. A menu should have appeared. Check the box next to your radio module (it should be labeled something like `/dev/ttyUSB`). Then press "**Next >**".
 5. Then, configure the port parameters to the specifications below:
-    > **Baud Rate**: `9600`
-    
-    > **Data Bits**: `8`
-    
-    > **Parity**: `None`
-    
-    > **Stop Bits**: `1`
-    
-    > **Flow Control**: `None`
-    
-Then click _finish_.
 
-6. XCTU should now show your module on the left. Click it, and wait for the configuration settings to appear on the right side of the screen.
-7. Set the PAN ID (Channel) to a number of your choosing. Also, set a device role for your module. If this is the first device in your area, select "Form network". If not, select "Join network".
-8. On the search bar at the top, type "AP". Find the option "`AP API Enable`" to "`API Mode Without Escapes [1]`".
-9. Press the _"Write"_ button (with the pencil icon) to save the changes to the XBee module.
+    | Parameter    | Value  |
+    |--------------|--------|
+    | Baud Rate    | 9600   |
+    | Data Bits    | 8      |
+    | Parity       | None   |
+    | Stop Bits    | 1      |
+    | Flow Control | None   |
+
+6. Click "**finish**".
+7. XCTU should now show your module on the left. Click it, and wait for the configuration settings to appear on the right side of the screen.
+8. Set the PAN ID (Channel) to a number of your choosing. Also, set a device role for your module. If this is the first device in your area, select "**Form network**". If not, select "**Join network**".
+9. On the search bar at the top, type `AP`. Find the option `AP API Enable` and set it to `API Mode Without Escapes [1]`.
+10. Press the "**Write**" button (with the pencil icon) to save the changes to the XBee module.
 
 You are now ready to move on to the next step.
 
-### Setting Up BeeChat    
-BeeChat comes as a precompiled .jar archive [which can be downloaded here](https://beechat.network/downloads-page/). Alternatively, [you can download the source code yourself](https://github.com/beechatnetworkadmin/BeeChatNetwork) and compile it manually; although this is not recommended and will not be covered in this guide. 
+## Running BeeChat
 
-1. [Download the executable .jar file](https://beechat.network/downloads/BeeChat.jar)
-2. Execute the .jar file
+BeeChat comes as a precompiled `.jar` archive [which can be downloaded here](https://beechat.network/downloads-page/).
 
-The .jar file must be executed within a terminal. To do this, open a terminal in the same directory as the .jar file and type `java -jar BeeChat.jar`. 
+1. [Download the executable `.jar` file](https://beechat.network/downloads/BeeChat.jar)
+2. Open a terminal in the same directory as the downloaded `.jar` file and execute it with `java -jar BeeChat.jar`
+    * Depending on your system, this may require super user privileges, so you might need to run `sudo java -jar BeeChat.jar` instead
 
-* Depending on your system, this may require super user privileges. 
-* So if it doesn't work, try `sudo java -jar BeeChat.jar`
-
-
-#### Command line arguments
+### Command line arguments
 
 No command line arguments are currently supported.
-
 
 ## Using BeeChat
 
 Coming soon!
-    
-        
+
+## Building BeeChat from source
+
+Coming soon!
+
 ## In The Future
-* Need a ubuntu/deb user to explain how to install java 11 on their OS please (APT), i forgot 
-* Tips on compiling from source
+
 * In "setting up the hardware" it is stated that "other zigbee hardware can be used". Can a programmer confirm this?
 * Current tutorial only supports linux systems, need to extend for windows/mac
 * Pictures are needed, they wont work right for me when making this so someone else needs to do em ig
 
-
-Questions? Comments? Recommendations? 
+Questions? Comments? Recommendations?
 [Email us!](beechatnetwork@gmail.com)
 
-Written by MysteryCombatMan 
+Written by MysteryCombatMan
 > Tox: BA21693673F2DFC79411BB4C7507789229058449A380721995B0B0743403984C659C54BB9993
-
-


### PR DESCRIPTION
Hi, saw your post on /g/ and decided to contribute by improving the tutorial and readme.

- The readme is now more presentable; you already have a `LICENSE` file and I don't think anyone likes to see legal mumbo-jumbo the first time they look at a repository.
- The changes to the tutorial are focused on improving its formatting and adding instructions for Ubuntu.

The commit messages explain all the changes in detail.

---

Off-topic: consider adding support for building the project with Gradle and/or Maven instead of the current `build.xml` with hard-coded paths and Eclipse specific stuff (`.classpath`, `.project` and the like). Gradle 6.4 is actually releasing soon with native support for Java modules. I might make such a contribution in the future if I find time for that and if no one does it before then.

I respect your initiative and wish you the best of luck.